### PR TITLE
Upgrade the Omnibus packages version

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,4 @@
-default[:omnibus_updater][:version] = '10.12.0-1'
+default[:omnibus_updater][:version] = '10.14.2-1'
 default[:omnibus_updater][:base_uri] = 'http://opscode-omnitruck-release.s3.amazonaws.com'
 default[:omnibus_updater][:cache_dir] = '/opt'
 default[:omnibus_updater][:cache_omnibus_installer] = false


### PR DESCRIPTION
It seems like there is already a new stable version of the Omnibus package at http://opscode-omnitruck-release.s3.amazonaws.com/

This is a minor change to update that version. The Chef 10.14.2 comes with a lot of bug fixes so I guest It could be interesting to have this upgraded.

Thanks for the cookbook :-)
