### PR TITLE
Convert deletion of historic debs to a native chef resource

### DIFF
--- a/recipes/_old_deb_cleaner.rb
+++ b/recipes/_old_deb_cleaner.rb
@@ -1,0 +1,14 @@
+old_debs =
+  if ::File.exist?(node[:omnibus_updater][:cache_dir])
+    Dir.glob(File.join(node[:omnibus_updater][:cache_dir], 'chef*.deb')).delete_if do |file|
+      file.include?(node[:omnibus_updater][:version])
+    end
+  else
+    []
+  end
+
+old_debs.each do |filename|
+  file filename do
+    action :delete
+  end
+end

--- a/recipes/deb_downloader.rb
+++ b/recipes/deb_downloader.rb
@@ -12,13 +12,4 @@ remote_file "chef omnibus_package_downloader[#{File.basename(node[:omnibus_updat
   end
 end
 
-ruby_block "omnibus_updater[remove old debs]" do
-  block do
-    Dir.glob(File.join(node[:omnibus_updater][:cache_dir], 'chef*.deb')).each do |file|
-      unless(file.include?(node[:omnibus_updater][:version]))
-        Chef::Log.info "Deleting stale omnibus package: #{file}"
-        File.delete(file)
-      end
-    end
-  end
-end
+include_recipe 'omnibus_updater::_old_deb_cleaner'

--- a/recipes/deb_package.rb
+++ b/recipes/deb_package.rb
@@ -26,13 +26,4 @@ execute "chef omnibus_install[#{node[:omnibus_updater][:version]}]" do
   end
 end
 
-ruby_block "omnibus_updater[remove old debs]" do
-  block do
-    Dir.glob(File.join(node[:omnibus_updater][:cache_dir], 'chef*.deb')).each do |file|
-      unless(file.include?(node[:omnibus_updater][:version]))
-        Chef::Log.info "Deleting stale omnibus package: #{file}"
-        File.delete(file)
-      end
-    end
-  end
-end
+include_recipe 'omnibus_updater::_old_deb_cleaner'


### PR DESCRIPTION
Update the deb_downloader and deb_package recipes to use native Chef resources when deleting historic debs. This avoids the scenario where the ruby resource always executes.
