### PR TITLE
fix non-terminated grouping in version regex

### DIFF
--- a/recipes/set_remote_path.rb
+++ b/recipes/set_remote_path.rb
@@ -112,7 +112,7 @@ unless(remote_omnibus_file == node[:omnibus_updater][:full_uri])
 end
 
 unless(node[:omnibus_updater][:full_version])
-  node.default[:omnibus_updater][:version] = remote_omnibus_file.scan(/chef[_-](\d+\.\d+\.\d+/).flatten.first
+  node.default[:omnibus_updater][:version] = remote_omnibus_file.scan(/chef[_-](\d+\.\d+\.\d+)/).flatten.first
   if(node[:omnibus_updater][:version].include?('-'))
     node.default[:omnibus_updater][:full_version] = node[:omnibus_updater][:version]
   else


### PR DESCRIPTION
master is failing with ruby error on v0.0.5.  This fixes the error

```
 FATAL: Cookbook file recipes/set_remote_path.rb has a ruby syntax error:
 FATAL: cookbooks/omnibus_updater/recipes/set_remote_path.rb:115: end pattern with unmatched parenthesis: /chef[_-](\d+\.\d+\.\d+/
```
