### PR TITLE
fix to support debian as well as ubuntu systems

### DIFF
--- a/recipes/set_remote_path.rb
+++ b/recipes/set_remote_path.rb
@@ -50,7 +50,14 @@ when 'debian'
       raise 'Unsupported ubuntu version for deb packaged omnibus'
     end
   else
-    platform_version = platform_majorversion = node.platform_version.split('.').first
+    platform_version = case pv = node.platform_version.split('.').first
+    when '6', '5'
+      platform_majorversion << '6'
+      '6.0.5'
+    else
+      platform_majorversion << pv
+      pv
+    end
   end
 when 'fedora', 'rhel'
   platform_version = node.platform_version.split('.').first


### PR DESCRIPTION
I looks like your updates to omnibus_updater have lost the patch to allow debian rather that just ubuntu systems to work.

failing path generated by omnibus_updater 
http://opscode-omnitruck-release.s3.amazonaws.com/debian/6/x86_64/chef_10.18.2-2.debian.6_amd64.deb

correct path
http://opscode-omnitruck-release.s3.amazonaws.com/debian/6/x86_64/chef_10.18.2-2.debian.6.0.5_amd64.deb

In recipes/set_remote_path.rb if you replace the debian/ubuntu section with the following it should fix it again.
