### PR TITLE
Change default base URI to use opscode-omnibus-packages

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,6 @@
 default[:omnibus_updater][:version] = '10.18.2'
 default[:omnibus_updater][:version_search] = false
-default[:omnibus_updater][:base_uri] = 'http://opscode-omnitruck-release.s3.amazonaws.com'
+default[:omnibus_updater][:base_uri] = 'https://opscode-omnibus-packages.s3.amazonaws.com'
 default[:omnibus_updater][:cache_dir] = '/opt'
 default[:omnibus_updater][:cache_omnibus_installer] = false
 default[:omnibus_updater][:remove_chef_system_gem] = false


### PR DESCRIPTION
Also enables SSL.

Old default was 'http://opscode-omnitruck-release.s3.amazonaws.com', some client
packages are unavailable at this source. (eg 11.4.4 on Ubuntu).

The new URI is taken from files offered from the official Opscode download page
(http://www.opscode.com/chef/install/).

`${BASE_URI}/ubuntu/11.04/x86_64/chef_11.4.4-2.ubuntu.11.04_amd64.deb` works with this change when it didn't work with the previous base URI.

I have no insight into whether this is the new official URL from Opscode, or if the old one is truly deprecated. However, this seems to work.
