### PR TITLE
No more normal attributes

### DIFF
--- a/recipes/downloader.rb
+++ b/recipes/downloader.rb
@@ -13,7 +13,7 @@ else
 end
 
 if(remote_path)
-  node.set[:omnibus_updater][:full_url] = remote_path
+  node.default[:omnibus_updater][:full_url] = remote_path
   Chef::Log.info "Omnibus Updater remote path: #{remote_path}"
 
   remote_file "omnibus_remote[#{File.basename(remote_path)}]" do


### PR DESCRIPTION
Setting full_url in normal attribute seems useless since we don't use
the value accross successive chef runs.
