### PR TITLE
Freshen instead of upgrade on RPM installs

### DIFF
--- a/recipes/installer.rb
+++ b/recipes/installer.rb
@@ -13,7 +13,7 @@ execute "omnibus_install[#{File.basename(remote_path)}]" do
   when '.deb'
     command "dpkg -i #{File.join(node[:omnibus_updater][:cache_dir], File.basename(remote_path))}"
   when '.rpm'
-    command "rpm -Uvh #{File.join(node[:omnibus_updater][:cache_dir], File.basename(remote_path))}"
+    command "rpm -Fvh #{File.join(node[:omnibus_updater][:cache_dir], File.basename(remote_path))}"
   when '.sh'
     command "/bin/sh #{File.join(node[:omnibus_updater][:cache_dir], File.basename(remote_path))}"
   else


### PR DESCRIPTION
Addresses issue #22. 

If the installed version of chef-client matches the omnibus_updater download,
upgrade (-U) will exit with an error on the first-run.

This changes `rpm --upgrade` to `rpm --freshen`, which doesn't exit with a non-zero status code if the same package is already installed, and fixes this problem.

I'm unsure if people ever use omnibus_updater to do an initial chef-client install -- this will break that use-case. README isn't clear if that's in scope for the cookbook. 
