### PR TITLE
deal with the insanity of amazon linux

### DIFF
--- a/libraries/omnitrucker.rb
+++ b/libraries/omnitrucker.rb
@@ -35,7 +35,9 @@ module OmnibusTrucker
           end.flatten.compact
       )]
       unless(@attrs)
-        if(set[:platform_family] == 'rhel')
+        if(set[:platform] == 'amazon')
+          @attrs = {:platform => 'el', :platform_version => 6}
+        elsif(set[:platform_family] == 'rhel')
           @attrs = {:platform => 'el', :platform_version => set[:platform_version].to_i}
         else
           @attrs = {:platform => set[:platform], :platform_version => set[:platform_version]}


### PR DESCRIPTION
amazon linux's platform version is 2013.06, but platform_family is rhel. 
