### PR TITLE
added logic to not attempt updates on debian 5 based system

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,5 +1,7 @@
 if(node[:omnibus_updater][:disabled])
   Chef::Log.warn 'Omnibus updater disabled via `disabled` attribute'
+elsif node[:platform] == "debian" and node[:platform_version].scan("5")
+  Chef::Log.warn 'Omnibus updater does not support Debian 5'
 else
   include_recipe 'omnibus_updater::downloader'
   include_recipe 'omnibus_updater::installer'


### PR DESCRIPTION
We have a lot of debian 5 based system.  Omnibus updater does not handle deb5 at all. Currently you get a very ugly chef error. This pull simply log's a warning stating that deb5 is not supported and continues on. 
