### PR TITLE
Debian versions need to be major-only.

### DIFF
--- a/libraries/omnitrucker.rb
+++ b/libraries/omnitrucker.rb
@@ -37,6 +37,8 @@ module OmnibusTrucker
       unless(@attrs)
         if(set[:platform_family] == 'rhel')
           @attrs = {:platform => 'el', :platform_version => set[:platform_version].to_i}
+        elsif(set[:platform] == 'debian')
+          @attrs = {:platform => set[:platform], :platform_version => set[:platform_version].to_i}
         else
           @attrs = {:platform => set[:platform], :platform_version => set[:platform_version]}
         end


### PR DESCRIPTION
omnibus_updater fails on Debian-versions other than 6.0.5.

This applies the same fix as with RHEL, and just uses the major version.
