### PR TITLE
Added support for restarting the chef-client service after an upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ longer exist. The currently running instance can encounter unexpected states bec
 of this. To prevent this, the updater will attempt to kill the Chef instance so
 that it can be restarted in a normal state.
 
+Restart chef-client Service
+---------------------------
+
+Use the `restart_chef_service` attribute to restart chef-client if you have it running as a service.
+
 Prerelease
 --------
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,3 +7,4 @@ default[:omnibus_updater][:prerelease] = false
 default[:omnibus_updater][:disabled] = false
 default[:omnibus_updater][:kill_chef_on_upgrade] = true
 default[:omnibus_updater][:always_download] = false
+default[:omnibus_updater][:restart_chef_service] = false

--- a/recipes/installer.rb
+++ b/recipes/installer.rb
@@ -20,6 +20,9 @@ execute "omnibus_install[#{File.basename(remote_path)}]" do
     raise "Unknown package type encountered for install: #{File.extname(remote_path)}"
   end
   action :nothing
+  if node[:omnibus_updater][:restart_chef_service]
+      notifies :restart, "service[chef-client]", :immediately
+  end
   notifies :create, 'ruby_block[omnibus chef killer]', :immediately
 end
 


### PR DESCRIPTION
This should address issue: https://github.com/hw-cookbooks/omnibus_updater/issues/33

If the restart_chef_service attribute is set it will restart the chef-client service before killing the run.
