### PR TITLE
fixing issues with updating omnibus chef client on mac os x

### DIFF
--- a/libraries/omnitrucker.rb
+++ b/libraries/omnitrucker.rb
@@ -41,6 +41,8 @@ module OmnibusTrucker
           @attrs = {:platform => 'el', :platform_version => set[:platform_version].to_i}
         elsif(set[:platform] == 'debian')
           @attrs = {:platform => set[:platform], :platform_version => set[:platform_version].to_i}
+        elsif(set[:platform_family] == 'mac_os_x')
+          @attrs = {:platform => set[:platform_family], :platform_version => [set[:platform_version].to_f, 10.7].min}
         else
           @attrs = {:platform => set[:platform], :platform_version => set[:platform_version]}
         end


### PR DESCRIPTION
This fixes 3 things:
- The omnitruck api only supports major and minor version for the mac os x platform version. The current implementation of the omnibus_updater cookbook is passing the major, minor, and patch and this causes the downloader to fail with a 404 because the download it's looking for doesn't exist. This fix drops the patch version, so, for example, on os x 10.8.5, the platform version will be 10.8 instead of 10.8.5. This is in the omnitruck api documentation at: http://docs.opscode.com/api_omnitruck.html
- Although the omnitruck api documentation specifies that it supports mac os x platform version 10.6, 10.7, 10.8, and 10.9, in practice it only support those versions for the metadata api. The download api only supports 10.6 and 10.7. If you give the metadata api platform version 10.8 or 10.9 it actually points you to the 10.7 download. I have brought this up to Chef/Opscode's attention, but in the meantime, this fix will limit the platform version for mac os x to a max of 10.7
- As for platform, the values for mac systems are mac_os_x and mac_os_x_server. The omnitruck api doesn't support mac_os_x_server so we need to use node.platform_family instead of node.platform for mac os x systems. Ref: https://wiki.opscode.com/display/chef10/Using+Different+Platforms and https://github.com/opscode/chef/blob/master/lib/chef/platform/provider_mapping.rb
