### PR TITLE
Adds chef-client service

### DIFF
--- a/recipes/installer.rb
+++ b/recipes/installer.rb
@@ -6,6 +6,10 @@ file '/tmp/nocheck' do
   only_if { node['os'] =~ /^solaris/ }
 end
 
+service "chef-client" do
+  action :nothing
+end
+
 ruby_block 'omnibus chef killer' do
   block do
     raise 'New omnibus chef version installed. Killing Chef run!'


### PR DESCRIPTION
Fixes an issue where if restart_chef_service is set to true,
the notification to restart the chef-client service raises an
error that chef-client service is not defined.
