### PR TITLE
Upgrade Chef version immediately instead of waiting until the end of the run

### DIFF
--- a/recipes/installer.rb
+++ b/recipes/installer.rb
@@ -40,7 +40,7 @@ ruby_block 'Omnibus Chef install notifier' do
   block{ true }
   action :nothing
   subscribes :create, resources(:remote_file => "omnibus_remote[#{File.basename(remote_path)}]"), :immediately
-  notifies :run, resources(:execute => "omnibus_install[#{File.basename(remote_path)}]"), :delayed
+  notifies :run, resources(:execute => "omnibus_install[#{File.basename(remote_path)}]"), :immediately
 end
 
 include_recipe 'omnibus_updater::old_package_cleaner'


### PR DESCRIPTION
The way the `default` recipe is currently wired, a new version of Chef will not be installed until the very end of the first chef run.

Example:
1. You lock the Chef version to 11.8.2 using the attributes in this cookbook.
2. You perform a standard bootstrap and initial run on a new node using `knife ec2 server create ...`; this installs Chef version 11.10.4.
3. During your run the cookbook downloads the desired version of Chef and triggers a _delayed_ notification to install it and kill the current run.
4. **End Result**: The first run always executes using whatever version of Chef was initially installed and only subsequent runs use the version you specified.

I'm not sure why a `ruby_block` resource was used as a notification bus here but, regardless, a notification should trigger immediately. People can then use this as the 1st recipe in their run list and it will ensure that their nodes are locked to a specific version of Chef for ALL runs.
