### PR TITLE
Only fire off the installer if installed chef-client != desired

### DIFF
--- a/recipes/installer.rb
+++ b/recipes/installer.rb
@@ -41,6 +41,7 @@ ruby_block 'Omnibus Chef install notifier' do
   action :nothing
   subscribes :create, resources(:remote_file => "omnibus_remote[#{File.basename(remote_path)}]"), :immediately
   notifies :run, resources(:execute => "omnibus_install[#{File.basename(remote_path)}]"), :delayed
+  only_if { node['chef_packages']['chef']['version'] != node['omnibus_updater']['version'] }
 end
 
 include_recipe 'omnibus_updater::old_package_cleaner'


### PR DESCRIPTION
We were running into issues with packages not downloading entirely and not firing off installs- which prompted me to force the client to always download packages. Since that's the only criterion for whether or not an install (and thus bailout) should be attempted, I added a little more caution to the appropriate resource.
