### PR TITLE
Fix adding script_options to script_command

### DIFF
--- a/recipes/installer.rb
+++ b/recipes/installer.rb
@@ -58,7 +58,7 @@ if(node[:omnibus_updater][:install_sh][:enabled])
     script_options['-v'] = node[:omnibus_updater][:version]
   end
 
-  script_command.push(script_options.flatten).flatten.compact.join(' ')
+  script_command.push(*script_options.flatten)
 
   execute "omnibus_install[#{resource_ident}]" do
     command script_command


### PR DESCRIPTION
Without this fix, the branch errors out of the existing integration test with the following stacktrace:

```
TypeError: execute[omnibus_install[v11.18]] (omnibus_updater::installer line 79) had an error: TypeError: no implicit conversion from nil to integer
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/mixlib-shellout-1.4.0/lib/mixlib/shellout/unix.rb:350:in `kill'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/mixlib-shellout-1.4.0/lib/mixlib/shellout/unix.rb:350:in `reap_errant_child'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/mixlib-shellout-1.4.0/lib/mixlib/shellout/unix.rb:97:in `ensure in run_command'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/mixlib-shellout-1.4.0/lib/mixlib/shellout/unix.rb:105:in `run_command'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/mixlib-shellout-1.4.0/lib/mixlib/shellout.rb:227:in `run_command'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.14.6/lib/chef/mixin/shell_out.rb:37:in `shell_out'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.14.6/lib/chef/mixin/shell_out.rb:42:in `shell_out!'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.14.6/lib/chef/provider/execute.rb:60:in `block in action_run'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.14.6/lib/chef/mixin/why_run.rb:52:in `call'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.14.6/lib/chef/mixin/why_run.rb:52:in `add_action'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.14.6/lib/chef/provider.rb:156:in `converge_by'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.14.6/lib/chef/provider/execute.rb:59:in `action_run'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.14.6/lib/chef/provider.rb:121:in `run_action'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.14.6/lib/chef/resource.rb:648:in `run_action'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.14.6/lib/chef/runner.rb:49:in `run_action'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.14.6/lib/chef/runner.rb:57:in `block in run_action'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.14.6/lib/chef/runner.rb:55:in `each'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.14.6/lib/chef/runner.rb:55:in `run_action'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.14.6/lib/chef/runner.rb:81:in `block (2 levels) in converge'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.14.6/lib/chef/runner.rb:81:in `each'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.14.6/lib/chef/runner.rb:81:in `block in converge'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.14.6/lib/chef/resource_collection.rb:98:in `block in execute_each_resource'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.14.6/lib/chef/resource_collection/stepable_iterator.rb:116:in `call'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.14.6/lib/chef/resource_collection/stepable_iterator.rb:116:in `call_iterator_block'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.14.6/lib/chef/resource_collection/stepable_iterator.rb:85:in `step'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.14.6/lib/chef/resource_collection/stepable_iterator.rb:104:in `iterate'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.14.6/lib/chef/resource_collection/stepable_iterator.rb:55:in `each_with_index'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.14.6/lib/chef/resource_collection.rb:96:in `execute_each_resource'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.14.6/lib/chef/runner.rb:80:in `converge'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.14.6/lib/chef/client.rb:345:in `converge'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.14.6/lib/chef/client.rb:431:in `do_run'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.14.6/lib/chef/client.rb:213:in `block in run'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.14.6/lib/chef/client.rb:207:in `fork'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.14.6/lib/chef/client.rb:207:in `run'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.14.6/lib/chef/application.rb:236:in `run_chef_client'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.14.6/lib/chef/application/solo.rb:226:in `block in run_application'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.14.6/lib/chef/application/solo.rb:218:in `loop'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.14.6/lib/chef/application/solo.rb:218:in `run_application'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.14.6/lib/chef/application.rb:55:in `run'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.14.6/bin/chef-solo:25:in `<top (required)>'
/opt/chef/bin/chef-solo:23:in `load'
/opt/chef/bin/chef-solo:23:in `<main>'
```