### PR TITLE
Resolve warnings

### DIFF
--- a/recipes/downloader.rb
+++ b/recipes/downloader.rb
@@ -33,7 +33,7 @@ else
 end
 
 if(remote_path)
-  node.set[:omnibus_updater][:full_url] = remote_path
+  node.override[:omnibus_updater][:full_url] = remote_path
 
   directory node[:omnibus_updater][:cache_dir] do
     recursive true


### PR DESCRIPTION
Remove node.set usage to resolve warnings with newer chef-clients.

```
 node.set is deprecated and will be removed in Chef 14, please use node.default/node.override (or node.normal only if you really need persistence) at 2 locations:
    - /var/chef/cache/cookbooks/omnibus_updater/recipes/downloader.rb:36:in `from_file'
```