### PR TITLE
Move Chef directory before upgrade on Windows

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,7 @@ namespace :style do
     FoodCritic::Rake::LintTask.new(:chef) do |t|
       t.options = {
         fail_tags: ['any'],
-        progress: true
+        progress: true,
       }
     end
   rescue LoadError


### PR DESCRIPTION
Fixes https://github.com/chef/chef/issues/4623

By moving the directory, the chef-client can continue to access open files.
We then delete the old directory on a subsequent run where we would now be
using files in the standard directory.

Tested Chef 12.5.1   -> Chef 12.17.44
Tested Chef 12.15.19 -> Chef 12.17.44